### PR TITLE
714 - Add administrative-gender HL7 FHIR value set and use it in HOT Questionnaire

### DIFF
--- a/HomeOxygenTherapy/R4/resources/Questionnaire-R4-HomeOxygenTherapy.json
+++ b/HomeOxygenTherapy/R4/resources/Questionnaire-R4-HomeOxygenTherapy.json
@@ -33,30 +33,6 @@
       }
     }
   ],
-  "contained": [
-    {
-      "resourceType": "ValueSet",
-      "id": "gender",
-      "url": "#gender",
-      "status": "draft",
-      "expansion": {
-        "contains": [
-          {
-            "code": "male",
-            "display": "Male"
-          },
-          {
-            "code": "female",
-            "display": "Female"
-          },
-          {
-            "code": "other",
-            "display": "Other"
-          }
-        ]
-      }
-    }
-  ],
   "item": [
     {
       "linkId": "1",
@@ -128,7 +104,7 @@
           "text": "Gender",
           "type": "choice",
           "required": true,
-          "answerValueSet": "#gender",
+          "answerValueSet": "http://hl7.org/fhir/ValueSet/administrative-gender",
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",

--- a/Shared/R4/resources/ValueSet-R4-administrative-gender.json
+++ b/Shared/R4/resources/ValueSet-R4-administrative-gender.json
@@ -1,0 +1,142 @@
+{
+  "resourceType" : "ValueSet",
+  "id" : "administrative-gender",
+  "meta" : {
+    "versionId" : "1",
+    "lastUpdated" : "2018-12-14T02:04:45.957Z",
+    "profile" : [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "text" : {
+    "status" : "generated",
+    "div" : "<div><table class=\"grid\"><tr><td>http://hl7.org/fhir/administrative-gender</td><td>male</td><td>Male</td></tr><tr><td>http://hl7.org/fhir/administrative-gender</td><td>female</td><td>Female</td></tr><tr><td>http://hl7.org/fhir/administrative-gender</td><td>other</td><td>Other</td></tr><tr><td>http://hl7.org/fhir/administrative-gender</td><td>unknown</td><td>Unknown</td></tr></table></div>"
+  },
+  "extension" : [
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode" : "pa"
+    },
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+      "valueCode" : "normative"
+    },
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger" : 5
+    },
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-normative-version",
+      "valueCode" : "4.0.0"
+    }
+  ],
+  "url" : "http://hl7.org/fhir/ValueSet/administrative-gender",
+  "identifier" : [
+    {
+      "system" : "urn:ietf:rfc:3986",
+      "value" : "urn:oid:2.16.840.1.113883.4.642.3.1"
+    }
+  ],
+  "version" : "4.0.0",
+  "name" : "AdministrativeGender",
+  "title" : "AdministrativeGender",
+  "status" : "active",
+  "experimental" : false,
+  "date" : "2018-12-14T01:14:32+00:00",
+  "publisher" : "HL7 (FHIR Project)",
+  "contact" : [
+    {
+      "telecom" : [
+        {
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        },
+        {
+          "system" : "email",
+          "value" : "fhir@lists.hl7.org"
+        }
+      ]
+    }
+  ],
+  "description" : "The gender of a person used for administrative purposes.",
+  "immutable" : true,
+  "compose" : {
+    "include" : [
+      {
+        "system" : "http://hl7.org/fhir/administrative-gender"
+      }
+    ]
+  },
+  "expansion" : {
+    "identifier" : "urn:uuid:9758a8b3-f741-40f6-b497-1bb7cd611c09",
+    "timestamp" : "2020-05-07T17:13:35.193Z",
+    "parameter" : [
+      {
+        "name" : "expansion-source",
+        "valueString" : "ValueSet/administrative-gender"
+      },
+      {
+        "name" : "limitedExpansion",
+        "valueBoolean" : true
+      },
+      {
+        "name" : "displayLanguage",
+        "valueString" : "en-US,en;q=0.9"
+      },
+      {
+        "name" : "includeDefinition",
+        "valueBoolean" : true
+      },
+      {
+        "name" : "version",
+        "valueString" : "http://hl7.org/fhir/administrative-gender|4.0.0"
+      }
+    ],
+    "contains" : [
+      {
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+            "valueString" : "Male."
+          }
+        ],
+        "system" : "http://hl7.org/fhir/administrative-gender",
+        "code" : "male",
+        "display" : "Male"
+      },
+      {
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+            "valueString" : "Female."
+          }
+        ],
+        "system" : "http://hl7.org/fhir/administrative-gender",
+        "code" : "female",
+        "display" : "Female"
+      },
+      {
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+            "valueString" : "Other."
+          }
+        ],
+        "system" : "http://hl7.org/fhir/administrative-gender",
+        "code" : "other",
+        "display" : "Other"
+      },
+      {
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+            "valueString" : "Unknown."
+          }
+        ],
+        "system" : "http://hl7.org/fhir/administrative-gender",
+        "code" : "unknown",
+        "display" : "Unknown"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Small change to use an expansion of the http://hl7.org/fhir/ValueSet/administrative-gender valueset in the Home Oxygen Therapy Questionnaire.