### PR TITLE
Papvs

### DIFF
--- a/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
+++ b/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
@@ -23,6 +23,7 @@ context Patient
 
 // coverage requirement info
 define "RelevantDiagnoses": CodesFromConditions(Confirmed(ActiveOrRecurring([Condition: "Sleep Apnea or Breathing Related Sleep Disorder"])))
+define "OSADiagnosed": exists("RelevantDiagnoses")
 
 define OtherDiagnoses:
   CodesFromConditions(Confirmed(ActiveOrRecurring([Condition]))) except "RelevantDiagnoses"

--- a/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
+++ b/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
@@ -23,7 +23,6 @@ context Patient
 
 // coverage requirement info
 define "RelevantDiagnoses": CodesFromConditions(Confirmed(ActiveOrRecurring([Condition: "Sleep Apnea or Breathing Related Sleep Disorder"])))
-define "OSADiagnosed": exists("RelevantDiagnoses")
 
 define OtherDiagnoses:
   CodesFromConditions(Confirmed(ActiveOrRecurring([Condition]))) except "RelevantDiagnoses"

--- a/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
+++ b/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
@@ -6,8 +6,7 @@ codesystem "ICD-10-CM": 'http://hl7.org/fhir/sid/icd-10-cm'
 codesystem "LOINC": 'http://loinc.org'
 codesystem "SNOMED-CT": 'http://snomed.info/sct'
 
-//Obstructive Sleep Apnea
-code "G47.33": 'G47.33' from "ICD-10-CM"
+valueset "Sleep Apnea or Breathing Related Sleep Disorder": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.31'
 
 // AHI codes
 code "LP145624-5" :'LP145624-5' from "LOINC"
@@ -17,33 +16,29 @@ code "90566-1": '90566-1' from "LOINC"
 parameter device_request DeviceRequest
 
 
-define "OSA_Codes": { "G47.33" }
-
 define "AHI_Codes": { "LP145624-5" }
 define "RDI_Codes": { "90566-1" }
 
 context Patient
 
 // coverage requirement info
-define OsaDiagnosis:
-  if exists(Confirmed(ActiveOrRecurring([Condition: "OSA_Codes"]))) then 'OSA' else 'null'
-
-define OsaDiagnosisExists: exists(Confirmed(ActiveOrRecurring([Condition: "OSA_Codes"])))
+define "RelevantDiagnoses": CodesFromConditions(Confirmed(ActiveOrRecurring([Condition: "Sleep Apnea or Breathing Related Sleep Disorder"])))
 
 define OtherDiagnoses:
-  distinct(flatten(
-    [Condition] C
-      let ICD10Codings:
-        ((C.code.coding) CODING where CODING.system.value in {
-          'http://hl7.org/fhir/sid/icd-10',
-          'http://hl7.org/fhir/sid/icd-10-cm'
-        }
-        return CODING.code.value + ' - ' + CODING.display.value)
-      where C.clinicalStatus.coding.code = 'active'
-      and exists(ICD10Codings)
-      return ICD10Codings
-  ))
+  CodesFromConditions(Confirmed(ActiveOrRecurring([Condition]))) except "RelevantDiagnoses"
 
+define function CodesFromConditions(CondList List<Condition>):
+  distinct(flatten(
+    CondList C
+      let DiagnosesCodings:
+          (C.code.coding) CODING where CODING.system.value in {
+            'http://hl7.org/fhir/sid/icd-10',
+            'http://hl7.org/fhir/sid/icd-10-cm',
+            'http://snomed.info/sct'
+          }
+          return FHIRHelpers.ToCode(CODING)
+      return DiagnosesCodings
+  ))
 
 define DeviceRequestHcpcsCoding: singleton from (
   ((cast device_request.code as CodeableConcept).coding) coding
@@ -54,12 +49,6 @@ define PapDeviceRequested:
   if "DeviceRequestHcpcsCoding".code.value = 'E0470' then 'E0470'
   else if  "DeviceRequestHcpcsCoding".code.value = 'E0601' then 'E0601'
   else 'null'
-
-define "Today": Today()
-
-define "True": true
-
-define "False": false
 
 define "AHI": HighestObservation(WithUnit(Verified(ObservationLookBack([Observation: "AHI_Codes"], 3 months)), '/h'))
 define "RDI": HighestObservation(WithUnit(Verified(ObservationLookBack([Observation: "RDI_Codes"], 3 months)), '/h'))

--- a/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
+++ b/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
@@ -14,6 +14,7 @@ parameter device_request DeviceRequest
 
 context Patient
 
+define "False": false
 // coverage requirement info
 define "RelevantDiagnoses": CodesFromConditions(Confirmed(ActiveOrRecurring([Condition: "Sleep Apnea or Breathing Related Sleep Disorder"])))
 

--- a/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
+++ b/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesPrepopulation-0.1.0.cql
@@ -7,17 +7,10 @@ codesystem "LOINC": 'http://loinc.org'
 codesystem "SNOMED-CT": 'http://snomed.info/sct'
 
 valueset "Sleep Apnea or Breathing Related Sleep Disorder": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.31'
-
-// AHI codes
-code "LP145624-5" :'LP145624-5' from "LOINC"
-//RDI codes
-code "90566-1": '90566-1' from "LOINC"
+valueset "Apnea Hypopnea Index Rate Measurement": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.123'
+valueset "Respiratory Disturbance Index": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.133'
 
 parameter device_request DeviceRequest
-
-
-define "AHI_Codes": { "LP145624-5" }
-define "RDI_Codes": { "90566-1" }
 
 context Patient
 
@@ -50,23 +43,18 @@ define PapDeviceRequested:
   else if  "DeviceRequestHcpcsCoding".code.value = 'E0601' then 'E0601'
   else 'null'
 
-define "AHI": HighestObservation(WithUnit(Verified(ObservationLookBack([Observation: "AHI_Codes"], 3 months)), '/h'))
-define "RDI": HighestObservation(WithUnit(Verified(ObservationLookBack([Observation: "RDI_Codes"], 3 months)), '/h'))
+define "AHI": GetObservationValue(LastestObservation(WithUnit(Verified(ObservationLookBack([Observation: "Apnea Hypopnea Index Rate Measurement"], 3 months)), '/h')))
+define "RDI": GetObservationValue(LastestObservation(WithUnit(Verified(ObservationLookBack([Observation: "Respiratory Disturbance Index"], 3 months)), '/h')))
 
-define "AllAlergy": ConfirmedAllergy([AllergyIntolerance])
+define function LastestObservation(ObsList List<Observation>):
+  First(ObsList O sort by FHIRHelpers."ToDateTime"(issued) desc)
 
-define "AllDrugAllergyWithCode": 
-  distinct(flatten(
-    [AllergyIntolerance] A
-      let Codings: 
-        (A.code.coding) CODING where CODING.system.value in {
-          'http://www.nlm.nih.gov/research/umls/rxnorm'
-        }
-        return CODING.display.value + '-' + CODING.code.value
-      where exists(Codings)
-      return Codings 
-  ))
+define function GetObservationValue(Obs Observation): 
+  NullSafeToQuantityWithoutUnit(cast Obs.value as Quantity)
 
+define function NullSafeToQuantityWithoutUnit(Qty FHIR.Quantity):
+  if Qty is not null then Qty.value.value 
+  else null
 ////////////////////////////// Taken from CDS Connect Commons for FHIR, could replace with r4 version of helper library
 define function ActiveOrRecurring(CondList List<Condition>):
   CondList C where C.clinicalStatus.coding.code in {'active', 'relapse'}
@@ -87,22 +75,9 @@ define function Verified(ObsList List<Observation>):
 define function WithUnit(ObsList List<Observation>, Unit String):
   ObsList O where (cast O.value as Quantity).unit.value = Unit or (cast O.value as Quantity).code.value = Unit
 
-define function HighestObservation(ObsList List<Observation>):
-  Max(ObsList O return NullSafeToQuantity(cast O.value as Quantity))
-
 define function Confirmed(CondList List<Condition>):
   CondList C where C.verificationStatus.coding.code = 'confirmed'
 
-define function NullSafeToQuantity(Qty FHIR.Quantity):
-  if Qty is not null then
-    System.Quantity {
-      value: Qty.value.value,
-      unit: Coalesce(Qty.unit.value, Qty.code.value)
-    }
-  else null
 
-define function LowestObservation(ObsList List<Observation>):
-  Min(ObsList O return NullSafeToQuantity(cast O.value as Quantity))
 
-define function ConfirmedAllergy(AllergyList List<AllergyIntolerance>):
-  AllergyList A where A.verificationStatus.coding.code in {'confirmed'}
+

--- a/PositiveAirwayPressureDevices/R4/resources/Library-R4-PositiveAirwayPressureDevices-prepopulation.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Library-R4-PositiveAirwayPressureDevices-prepopulation.json
@@ -26,6 +26,17 @@
       }
     }
   ],
+  "dataRequirement": [
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.31"
+        }
+      ]
+    }
+  ],
   "content": [
     {
       "contentType": "application/elm+json",

--- a/PositiveAirwayPressureDevices/R4/resources/Library-R4-PositiveAirwayPressureDevices-prepopulation.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Library-R4-PositiveAirwayPressureDevices-prepopulation.json
@@ -35,6 +35,23 @@
           "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.31"
         }
       ]
+    }, { 
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.123"
+        }
+      ]
+    },
+    { 
+      "type": "Observation",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.133"
+        }
+      ]
     }
   ],
   "content": [

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -93,11 +93,6 @@
           "type": "open-choice",
           "answerOption": [],
           "repeats": "true"
-        },
-        {
-          "linkId": "4.3",
-          "text": "Describe",
-          "type": "text"
         }
       ]
     },

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -77,7 +77,7 @@
             }
           ],
           "linkId": "4.1",
-          "text": "OSA Diagnoses",
+          "text": "Relevant Diagnoses",
           "type": "open-choice",
           "answerOption": [],
           "repeats": "true"

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -63,7 +63,7 @@
     },
     {
       "linkId": "4",
-      "text": "Patient diagnosis:",
+      "text": "Patient diagnoses:",
       "type": "group",
       "item": [
         {
@@ -85,31 +85,24 @@
         {
           "linkId": "4.2",
           "text": "Other diagnoses",
-          "type": "group",
-          "item": [
+          "extension": [
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                  "valueExpression": {
-                    "language": "text/cql",
-                    "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
-                  }
-                }
-              ],
-              "linkId": "4.2.1",
-              "text": "Other",
-              "type": "open-choice",
-              "answerOption": [],
-              "repeats": "true"
-            },
-            {
-              "linkId": "4.2.2",
-              "text": "Describe",
-              "type": "text"
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
+              }
             }
-          ]
-        }   
+          ],
+          "type": "open-choice",
+          "answerOption": [],
+          "repeats": "true"
+        },
+        {
+          "linkId": "4.3",
+          "text": "Describe",
+          "type": "text"
+        }
       ]
     },
     {

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -83,21 +83,33 @@
           "repeats": "true"
         },
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
-              }
-            }
-          ],
           "linkId": "4.2",
-          "text": "Other diagnoses:",
-          "type": "open-choice",
-          "answerOption": [],
-          "repeats": "true"
-        }
+          "text": "Other diagnoses",
+          "type": "group",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
+                  }
+                }
+              ],
+              "linkId": "4.2.1",
+              "text": "Other",
+              "type": "open-choice",
+              "answerOption": [],
+              "repeats": "true"
+            },
+            {
+              "linkId": "4.2.2",
+              "text": "Describe",
+              "type": "text"
+            }
+          ]
+        }   
       ]
     },
     {

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -7,11 +7,7 @@
     },
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicPatientInfo-prepopulation"
-    },
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicPractitionerInfo-prepopulation"
+      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicClinicalInfo-prepopulation"
     }
   ],
   "id": "PositiveAirwayPressureDevices",
@@ -31,176 +27,39 @@
   "item": [
     {
       "linkId": "1",
-      "type": "group",
-      "item": [
+      "extension": [
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".LastName"
-              }
-            }
-          ],
-          "linkId": "1.1",
-          "text": "Last Name:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".FirstName"
-              }
-            }
-          ],
-          "linkId": "1.2",
-          "text": "First Name:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".MiddleInitial"
-              }
-            }
-          ],
-          "linkId": "1.3",
-          "text": "Middle Initial:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".DateOfBirth"
-              }
-            }
-          ],
-          "linkId": "1.4",
-          "text": "Date of Birth:",
-          "type": "date",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".Gender"
-              }
-            }
-          ],
-          "linkId": "1.5",
-          "text": "Gender:",
-          "type": "choice",
-          "required": true,
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "male",
-                "display": "Male"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "female",
-                "display": "Female"
-              }
-            }
-          ]
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".MedicareId"
-              }
-            }
-          ],
-          "linkId": "1.6",
-          "text": "Medicare ID:",
-          "type": "string",
-          "required": true
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/patient-info"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Patient/Beneficiary Demographics"
     },
     {
       "linkId": "2",
-      "text": "Provider who is performing face-to-face evaluation",
-      "type": "group",
-      "item": [
+      "extension": [
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".LastName"
-              }
-            }
-          ],
-          "linkId": "2.1",
-          "text": "Last Name",
-          "type": "string",
-          "required": false
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".FirstName"
-              }
-            }
-          ],
-          "linkId": "2.2",
-          "text": "First Name",
-          "type": "string",
-          "required": false
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".MiddleInitial"
-              }
-            }
-          ],
-          "linkId": "2.3",
-          "text": "Middle Initial",
-          "type": "string",
-          "required": false
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/practitioner-info"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Physician/NPP Demographics"
     },
     {
       "linkId": "3",
-      "text": "Date of F2F evaluation (MM/DD/YYYY):",
-      "type": "group",
-      "item": [
+      "extension": [
         {
-          "linkId": "3.1",
-          "type": "date"
+          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "valueExpression": {
+            "language": "text/cql",
+            "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+          }
         }
-      ]
+      ],
+      "text": "Date of in-person evaluation (MM/DD/YYYY):",
+      "type": "date"
     },
     {
       "linkId": "4",
@@ -213,33 +72,15 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OsaDiagnosis"
+                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".RelevantDiagnoses"
               }
             }
           ],
           "linkId": "4.1",
-          "type": "choice",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "OSA",
-                "display": "Obstructive Sleep Apnea"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "4.2",
-          "text": "Other:",
-          "type": "choice",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "Other",
-                "display": "Yes"
-              }
-            }
-          ]
+          "text": "OSA Diagnoses",
+          "type": "open-choice",
+          "answerOption": [],
+          "repeats": "true"
         },
         {
           "extension": [
@@ -251,22 +92,18 @@
               }
             }
           ],
-          "linkId": "4.3",
-          "text": "Other (describe):",
-          "type": "text"
+          "linkId": "4.2",
+          "text": "Other diagnoses:",
+          "type": "open-choice",
+          "answerOption": [],
+          "repeats": "true"
         }
       ]
     },
     {
       "linkId": "5",
-      "type": "group",
-      "item": [
-        {
-          "linkId": "5.1",
-          "text": "Order start date, if different from date of order (MM/DD/YYYY):",
-          "type": "date"
-        }
-      ]
+      "text": "Order start date, if different from date of order (MM/DD/YYYY):",
+      "type": "date"
     },
     {
       "linkId": "6",
@@ -277,62 +114,20 @@
           "linkId": "6.1",
           "text": "Device:",
           "type": "choice",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "initial",
-                "display": "Initial"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "revision",
-                "display": "Revision or change in equipment"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "replacement",
-                "display": "Replacement"
-              }
-            }
-          ]
+          "answerValueSet": "http://hl7.org/fhir/ValueSet/request-intent"
         },
         {
           "linkId": "6.2",
           "text": "Supplies:",
-          "type": "choice",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "initial",
-                "display": "Initial"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "reorder",
-                "display": "Reorder"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "other",
-                "display": "Other"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "6.3",
-          "text": "Other (description):",
-          "type": "text"
+          "type": "open-choice",
+          "answerValueSet": "http://hl7.org/fhir/ValueSet/request-intent"
         }
       ]
     },
     {
       "linkId": "7",
       "type": "group",
+      "text": "Order",
       "item": [
         {
           "linkId": "7.1",
@@ -351,6 +146,7 @@
           ],
           "linkId": "7.2",
           "type": "choice",
+          "text": "Device ordered",
           "answerOption": [
             {
               "valueCoding": {
@@ -369,60 +165,15 @@
       ]
     },
     {
-      "linkId": "9",
-      "type": "group",
-      "item": [
+      "linkId": "8",
+      "extension": [
         {
-          "linkId": "9.1",
-          "text": "Signature:",
-          "type": "string"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".FullName"
-              }
-            }
-          ],
-          "linkId": "9.2",
-          "text": "Name (Printed):",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".Today"
-              }
-            }
-          ],
-          "linkId": "9.3",
-          "text": "Date (MM/DD/YYYY):",
-          "type": "date",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".NPI"
-              }
-            }
-          ],
-          "linkId": "9.4",
-          "text": "NPI:",
-          "type": "string",
-          "required": true
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/provider-signature"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Provider Signature"
     }
   ]
 }

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevices.json
@@ -54,7 +54,7 @@
           "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+            "expression": "\"BasicClinicalInfoPrepopulation\".RequestEncounterDate"
           }
         }
       ],

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -75,13 +75,15 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".RelevantDiagnosisExists"
+                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".RelevantDiagnoses"
               }
             }
           ],
           "linkId": "4.1",
-          "type": "boolean",
-          "text": "Obstructive Sleep Apnea (G47.33)"
+          "type": "open-choice",
+          "text": "Relevant Diagnoses",
+          "answerOption": [],
+          "repeats": "true"
         },
         {
           "extension": [

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -86,22 +86,33 @@
           "repeats": "true"
         },
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
-              }
-            }
-          ],
           "linkId": "4.2",
-          "text": "Other diagnoses:",
-          "type": "open-choice",
-          "required": true,
-          "repeats": true,
-          "answerOption": []
-        }
+          "text": "Other diagnoses",
+          "type": "group",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
+                  }
+                }
+              ],
+              "linkId": "4.2.1",
+              "text": "Other",
+              "type": "open-choice",
+              "answerOption": [],
+              "repeats": "true"
+            },
+            {
+              "linkId": "4.2.2",
+              "text": "Describe",
+              "type": "text"
+            }
+          ]
+        }  
       ]
     },
     {
@@ -313,16 +324,42 @@
       "text": "Physical Examination With Vital Signs",
       "item": [
         {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
-              "valueCanonical": "questionnaire/vital-signs"
-            }
-          ],
           "linkId": "11.1",
-          "type": "display",
-          "text": "This is a placeholder for Vital Signs"
+          "type": "group",
+          "item": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+                  "valueCanonical": "questionnaire/vital-signs"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire-expand",
+                  "valueBoolean": true
+                }
+              ],
+              "linkId": "11.1.1",
+              "type": "display",
+              "text": "This is a placeholder for Vital Signs"
+            },
+            {
+              "required": true,
+              "linkId": "11.1.2",
+              "text": "Neck circumference (cm)",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RespiratoryAssistDevicesFaceToFacePrepopulation\".NeckCircumf"
+                  }
+                }
+              ],
+              "type": "quantity"
+            }
+          ]
         },
+        
         {
           "extension": [
             {

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -338,13 +338,6 @@
                   "valueCoding": {
                     "display": "cm"
                   }
-                },
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                  "valueExpression": {
-                    "language": "text/cql",
-                    "expression": "\"RespiratoryAssistDevicesFaceToFacePrepopulation\".NeckCircumf"
-                  }
                 }
               ],
               "type": "decimal"

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -65,7 +65,7 @@
     },
     {
       "linkId": "4",
-      "text": "Patient diagnosis:",
+      "text": "Patient diagnoses:",
       "type": "group",
       "required": true,
       "item": [
@@ -88,31 +88,24 @@
         {
           "linkId": "4.2",
           "text": "Other diagnoses",
-          "type": "group",
-          "item": [
+          "extension": [
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                  "valueExpression": {
-                    "language": "text/cql",
-                    "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
-                  }
-                }
-              ],
-              "linkId": "4.2.1",
-              "text": "Other",
-              "type": "open-choice",
-              "answerOption": [],
-              "repeats": "true"
-            },
-            {
-              "linkId": "4.2.2",
-              "text": "Describe",
-              "type": "text"
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OtherDiagnoses"
+              }
             }
-          ]
-        }  
+          ],
+          "type": "open-choice",
+          "answerOption": [],
+          "repeats": "true"
+        },
+        {
+          "linkId": "4.3",
+          "text": "Describe",
+          "type": "text"
+        }
       ]
     },
     {
@@ -360,7 +353,6 @@
             }
           ]
         },
-        
         {
           "extension": [
             {

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -326,6 +326,7 @@
         {
           "linkId": "11.1",
           "type": "group",
+          "text": "Vital Sign",
           "item": [
             {
               "extension": [

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -334,6 +334,12 @@
               "text": "Neck circumference (cm)",
               "extension": [
                 {
+                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                  "valueCoding": {
+                    "display": "cm"
+                  }
+                },
+                {
                   "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
                   "valueExpression": {
                     "language": "text/cql",
@@ -341,7 +347,7 @@
                   }
                 }
               ],
-              "type": "quantity"
+              "type": "decimal"
             }
           ]
         },

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -29,301 +29,39 @@
   "subjectType": [
     "Patient"
   ],
-  "contained": [
-    {
-      "resourceType": "ValueSet",
-      "id": "gender",
-      "url": "#gender",
-      "status": "draft",
-      "expansion": {
-        "contains": [
-          {
-            "code": "male",
-            "display": "Male"
-          },
-          {
-            "code": "female",
-            "display": "Female"
-          },
-          {
-            "code": "other",
-            "display": "Other"
-          }
-        ]
-      }
-    }
-  ],
   "item": [
     {
+      "linkId": "1",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "gtable"
-              }
-            ]
-          }
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/patient-info"
         }
       ],
-      "linkId": "1",
-      "type": "group",
-      "text": "Patient Information",
-      "item": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".LastName"
-              }
-            }
-          ],
-          "linkId": "1.1",
-          "text": "Last Name:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".FirstName"
-              }
-            }
-          ],
-          "linkId": "1.2",
-          "text": "First Name:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".MiddleInitial"
-              }
-            }
-          ],
-          "linkId": "1.3",
-          "text": "Middle Initial:",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".DateOfBirth"
-              }
-            }
-          ],
-          "linkId": "1.4",
-          "text": "Date of Birth:",
-          "type": "date",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".Gender"
-              }
-            }
-          ],
-          "linkId": "1.5",
-          "text": "Gender:",
-          "type": "choice",
-          "required": true,
-          "answerValueSet": "#gender"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPatientInfoPrepopulation\".MedicareId"
-              }
-            }
-          ],
-          "linkId": "1.6",
-          "text": "Medicare ID:",
-          "type": "string",
-          "required": true
-        }
-      ]
+      "type": "display",
+      "text": "This is a placeholder for Patient/Beneficiary Demographics"
     },
     {
+      "linkId": "2",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "gtable"
-              }
-            ]
-          }
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/practitioner-info"
         }
       ],
-      "linkId": "2",
-      "type": "group",
-      "text": "Provider who performed the face-to-face evaluation if different than signing provider",
-      "item": [
-        {
-          "linkId": "2.1",
-          "text": "Last Name",
-          "type": "string",
-          "required": false
-        },
-        {
-          "linkId": "2.2",
-          "text": "First Name",
-          "type": "string",
-          "required": false
-        },
-        {
-          "linkId": "2.3",
-          "text": "Middle Initial",
-          "type": "string",
-          "required": false
-        },
-        {
-          "linkId": "2.4",
-          "text": "NPI",
-          "type": "string",
-          "required": false
-        }
-      ]
+      "type": "display",
+      "text": "This is a placeholder for Physician/NPP Demographics"
     },
     {
       "linkId": "3",
-      "type": "group",
-      "text": "General questions",
-      "item": [
+      "extension": [
         {
-          "linkId": "3.1",
-          "text": "Date of encounter",
-          "type": "date",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".Today"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "3.2",
-          "text": "Is this a F2F evaluation of the patient’s need for a PAP device for OSA? ",
-          "type": "boolean",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".True"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "3.3",
-          "text": "Order purpose: ",
-          "type": "group",
-          "enableWhen": [
-            {
-              "question": "3.2",
-              "operator": "=",
-              "answerBoolean": true
-            }
-          ],
-          "item": [
-            {
-              "linkId": "3.3.1",
-              "type": "choice",
-              "required": false,
-              "answerOption": [
-                {
-                  "valueCoding": {
-                    "code": "Initial Evaluation"
-                  }
-                },
-                {
-                  "valueCoding": {
-                    "code": "Re-evaluation"
-                  }
-                }
-              ]
-            },
-            {
-              "linkId": "3.3.2",
-              "text": "Is there evidence of continued use of the PAP/CPAP device and supplies?",
-              "type": "boolean",
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-                  "valueExpression": {
-                    "language": "text/cql",
-                    "expression": "\"PositiveAirwayPressureDevicePrepopulation\".True"
-                  }
-                }
-              ],
-              "enableWhen": [
-                {
-                  "question": "3.3.1",
-                  "operator": "=",
-                  "answerCoding": {
-                    "code": "Re-evaluation"
-                  }
-                }
-              ]
-            },
-            {
-              "linkId": "3.3.3",
-              "text": "Describe",
-              "type": "string",
-              "enableWhen": [
-                {
-                  "question": "3.3.1",
-                  "operator": "=",
-                  "answerCoding": {
-                    "code": "Re-evaluation"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "linkId": "3.4",
-          "text": "If No, purpose of the encounter: ",
-          "type": "text",
-          "required": false,
-          "enableWhen": [
-            {
-              "question": "3.2",
-              "operator": "=",
-              "answerBoolean": false
-            }
-          ]
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/encounter-with-reevaluation"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Encounter with reevaluation"
     },
     {
       "linkId": "4",
@@ -337,7 +75,7 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".OsaDiagnosisExists"
+                "expression": "\"PositiveAirwayPressureDevicePrepopulation\".RelevantDiagnosisExists"
               }
             }
           ],
@@ -547,1028 +285,72 @@
     },
     {
       "linkId": "9",
-      "type": "group",
-      "text": "Medical History",
-      "item": [
-        {
-          "linkId": "9.1",
-          "type": "text",
-          "text": "Chief complaint / history of present illness and associated signs / symptoms:"
-        },
-        {
-          "linkId": "9.2",
-          "type": "text",
-          "text": "Related past medical / surgical history:"
-        }
-      ]
-    },
-    {
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "gtable"
-              }
-            ]
-          }
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/subjective"
         }
       ],
+      "type": "display",
+      "text": "This is a placeholder for Subjective"
+    },
+    {
       "linkId": "10",
-      "type": "group",
-      "repeats": true,
-      "text": "Medication",
-      "item": [
-        {
-          "linkId": "10.1",
-          "text": "RxNorm",
-          "type": "string"
-        },
-        {
-          "linkId": "10.2",
-          "text": "Description",
-          "type": "string"
-        },
-        {
-          "linkId": "10.3",
-          "text": "Dose",
-          "type": "string"
-        },
-        {
-          "linkId": "10.4",
-          "text": "Frequency",
-          "type": "string"
-        },
-        {
-          "linkId": "10.5",
-          "text": "Route",
-          "type": "string"
-        },
-        {
-          "linkId": "10.6",
-          "text": "Status",
-          "type": "choice",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "display": "New"
-              }
-            },
-            {
-              "valueCoding": {
-                "display": "Current"
-              }
-            },
-            {
-              "valueCoding": {
-                "display": "Modified"
-              }
-            },
-            {
-              "valueCoding": {
-                "display": "Discontinued"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "gtable"
-              }
-            ]
-          }
-        },
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-          "valueExpression": {
-            "language": "text/cql",
-            "expression": "\"PositiveAirwayPressureDevicePrepopulation\".AllDrugAllergyWithCode"
-          }
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/review-of-system"
         }
       ],
+      "type": "display",
+      "text": "This is a placeholder for Review Of System"
+    },
+    {
       "linkId": "11",
-      "type": "open-choice",
-      "repeats": true,
-      "text": "Allergies",
-      "answerOption": []
+      "type": "group",
+      "text": "Physical Examination With Vital Signs",
+      "item": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/vital-signs"
+            }
+          ],
+          "linkId": "11.1",
+          "type": "display",
+          "text": "This is a placeholder for Vital Signs"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+              "valueCanonical": "questionnaire/physical-exam"
+            }
+          ],
+          "linkId": "11.2",
+          "type": "display",
+          "text": "This is a placeholder for Physical Examination"
+        }
+      ]
     },
     {
-      "type": "group",
-      "required": false,
       "linkId": "12",
-      "text": "Review of systems (Significant as per history of present problem and home oxygen need):",
-      "item": [
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.1",
-          "text": "General",
-          "code": [
-            {
-              "code": "71407-1",
-              "display": "CMS - constitutional symptoms panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "weight gain"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "weight loss"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "sleeping problems"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "fatigue"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "fever"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "chills"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "night sweats / diaphoresis"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.2",
-          "text": "Neck",
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "lumps"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "pain on movement"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.3",
-          "text": "Pulmonary",
-          "code": [
-            {
-              "code": "71411-3",
-              "display": "CMS - respiratory panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "cough"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "shortness of breath"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "pain"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "wheezing"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "hemoptysis"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "sputum production"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.4",
-          "text": "Cardiac",
-          "code": [
-            {
-              "code": "71410-5",
-              "display": "CMS - cardiovascular panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "chest pain"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "palpitations"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "orthopnea"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "murmur"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "syncope"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "linkId": "12.5",
-          "text": "Vascular",
-          "required": false,
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "edema"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "claudication"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "varicose veins"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "thrombophlebitis"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "ulcers"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.6",
-          "text": "Gastrointestinal",
-          "code": [
-            {
-              "code": "71412-1",
-              "display": "CMS - gastrointestinal panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "swallowing problems"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "abdominal pain"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "constipation"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "diarrhea"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "incontinence"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "nausea"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "vomiting"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "ulcers"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "melena"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "rectal bleeding"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "jaundice"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "heartburn"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "hematemesis"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.7",
-          "text": "Musculoskeletal",
-          "code": [
-            {
-              "code": "71414-7",
-              "display": "CMS - musculoskeletal panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "pain"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "swelling"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "stiffness"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "limitation of range of motion"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "arthritis"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "gout"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "cramps"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "myalgia"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "fasciculation"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "atrophy"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "fracture"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "deformity"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "weakness"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.8",
-          "text": "Neurologic:",
-          "repeats": true,
-          "code": [
-            {
-              "code": "71416-2",
-              "display": "CMS - neurological panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "seizures"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "poor memory"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "poor concentration"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "numbness / tingling"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "pins and needles sensation"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "hyperpathia"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "dysesthesia"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "weakness"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "paralysis"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "tremors"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "involuntary movements"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "unstable gait"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "fall"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "vertigo"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "headache"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "stroke"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "speech disorders"
-              }
-            }
-          ]
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.9",
-          "text": "Psychiatric",
-          "code": [
-            {
-              "code": "71417-0",
-              "display": "CMS - psychiatric panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "display": "hallucinations",
-                "code": "LP74902-5",
-                "system": "http://loinc.org"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "delusions"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "anxiety"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "nervous breakdown"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "mood changes"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.10",
-          "text": "Hematology",
-          "code": [
-            {
-              "code": "71419-6",
-              "display": "CMS - hematologic - lymphatic panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "anemia"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "bruising"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "bleeding disorders (conditional)"
-              }
-            }
-          ],
-          "repeats": true
-        },
-        {
-          "type": "open-choice",
-          "required": false,
-          "linkId": "12.11",
-          "text": "Endocrine",
-          "code": [
-            {
-              "code": "71418-8",
-              "display": "CMS - endocrine panel",
-              "system": "http://loinc.org"
-            }
-          ],
-          "answerOption": [
-            {
-              "valueCoding": {
-                "code": "heat or cold intolerance"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "diabetes"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "lipid disorders"
-              }
-            },
-            {
-              "valueCoding": {
-                "code": "goiter"
-              }
-            }
-          ],
-          "repeats": true
-        }
-      ]
-    },
-    {
-      "linkId": "13",
-      "type": "group",
-      "text": "Physical examination",
-      "item": [
-        {
-          "linkId": "13.1",
-          "type": "group",
-          "text": "Vital Sign",
-          "item": [
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "8310-5",
-                  "display": "Body temperature",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "Cel"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.1",
-              "text": "Body temperature"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "9279-1",
-                  "display": "Resp rate",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "{breaths}/min"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.2",
-              "text": "Resp rate"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "8867-4",
-                  "display": "Heart rate",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "{beats}/min"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.3",
-              "text": "Heart rate"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "8480-6",
-                  "display": "BP sys",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "mm[Hg]"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.4",
-              "text": "BP sys"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "8462-4",
-                  "display": "BP dias",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "mm[Hg]"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.5",
-              "text": "BP dias"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "8302-2",
-                  "display": "Body height",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "[in_i]"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.6",
-              "text": "Body height"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "29463-7",
-                  "display": "Weight",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "kg"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.7",
-              "text": "Weight"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "59417-6",
-                  "display": "SaO2 Resting % BldA PulseOx",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "%"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.8",
-              "text": "SaO2 Resting % BldA PulseOx"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "56074-8",
-                  "display": "Circumference Neck",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "cm"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.9",
-              "text": "Neck circumference"
-            },
-            {
-              "type": "decimal",
-              "code": [
-                {
-                  "code": "39156-5",
-                  "display": "Body mass index (BMI)",
-                  "system": "http://loinc.org"
-                }
-              ],
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                  "valueCoding": {
-                    "display": "kg/m2"
-                  }
-                }
-              ],
-              "required": false,
-              "linkId": "13.1.9",
-              "text": "Body mass index (BMI)"
-            }
-          ]
-        },
-        {
-          "linkId": "13.2",
-          "type": "string",
-          "text": "General appearance"
-        },
-        {
-          "linkId": "13.3",
-          "type": "string",
-          "text": "Head and neck",
-          "code": [
-            {
-              "code": "71390-9",
-              "display": "CMS - head and face exam panel",
-              "system": "http://loinc.org"
-            },
-            {
-              "code": "71393-3",
-              "display": "CMS - neck exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.4",
-          "type": "string",
-          "text": "Chest / lungs",
-          "code": [
-            {
-              "code": "71394-1",
-              "display": "CMS - respiratory exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.5",
-          "type": "string",
-          "text": "Cardiovascular",
-          "code": [
-            {
-              "code": "71395-8",
-              "display": "CMS - cardiovascular exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.6",
-          "type": "string",
-          "text": "Abdominal",
-          "code": [
-            {
-              "code": "71397-4",
-              "display": "CMS - gastrointestinal - abdomen - exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.7",
-          "type": "string",
-          "text": "Musculoskeletal / extremities",
-          "code": [
-            {
-              "code": "71402-2",
-              "display": "CMS - musculoskeletal exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.8",
-          "type": "string",
-          "text": "Neurological",
-          "code": [
-            {
-              "code": "71404-8",
-              "display": "CMS - neurologic exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        },
-        {
-          "linkId": "13.9",
-          "type": "string",
-          "text": "Psychiatric",
-          "code": [
-            {
-              "code": "71405-5",
-              "display": "CMS - psychiatric exam panel",
-              "system": "http://loinc.org"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "14",
       "type": "text",
       "text": "Physician/NPP assessment / summary"
     },
     {
-      "linkId": "15",
+      "linkId": "13",
       "type": "group",
       "text": "Treatment Plan",
       "item": [
         {
-          "linkId": "15.1",
+          "linkId": "13.1",
           "type": "text",
           "text": "Description"
         },
         {
-          "linkId": "15.2",
+          "linkId": "13.2",
           "type": "text",
           "text": "Orders",
           "item": [
@@ -1586,23 +368,23 @@
                   }
                 }
               ],
-              "linkId": "15.2.1",
+              "linkId": "13.2.1",
               "type": "group",
               "text": "Medication",
               "repeats": true,
               "item": [
                 {
-                  "linkId": "15.2.1.1",
+                  "linkId": "13.2.1.1",
                   "text": "RxNorm",
                   "type": "string"
                 },
                 {
-                  "linkId": "15.2.1.2",
+                  "linkId": "13.2.1.2",
                   "text": "Dose",
                   "type": "string"
                 },
                 {
-                  "linkId": "15.2.1.3",
+                  "linkId": "13.2.1.3",
                   "text": "Description",
                   "type": "string"
                 }
@@ -1622,13 +404,13 @@
                   }
                 }
               ],
-              "linkId": "15.2.2",
+              "linkId": "13.2.2",
               "type": "group",
               "text": "Supplies",
               "repeats": true,
               "item": [
                 {
-                  "linkId": "15.2.2.1",
+                  "linkId": "13.2.2.1",
                   "text": "Name",
                   "type": "string"
                 },
@@ -1653,18 +435,18 @@
                   }
                 }
               ],
-              "linkId": "15.2.3",
+              "linkId": "13.2.3",
               "type": "group",
               "text": "Investigations (Diagnostic Testing)",
               "repeats": true,
               "item": [
                 {
-                  "linkId": "15.2.3.1",
+                  "linkId": "13.2.3.1",
                   "text": "Name",
                   "type": "string"
                 },
                 {
-                  "linkId": "15.2.3.2",
+                  "linkId": "13.2.3.2",
                   "text": "Description",
                   "type": "string"
                 }
@@ -1684,25 +466,25 @@
                   }
                 }
               ],
-              "linkId": "15.2.4",
+              "linkId": "13.2.4",
               "type": "group",
               "text": "Consult",
               "repeats": true,
               "item": [
                 {
-                  "linkId": "15.2.4.1",
+                  "linkId": "13.2.4.1",
                   "text": "Name",
                   "type": "string"
                 },
                 {
-                  "linkId": "15.2.4.2",
+                  "linkId": "13.2.4.2",
                   "text": "Description",
                   "type": "string"
                 }
               ]
             },
             {
-              "linkId": "15.2.4",
+              "linkId": "13.2.4",
               "text": "Other",
               "type": "text"
             }
@@ -1711,60 +493,15 @@
       ]
     },
     {
-      "linkId": "16",
-      "type": "group",
-      "item": [
+      "linkId": "14",
+      "extension": [
         {
-          "linkId": "16.1",
-          "text": "Signature:",
-          "type": "string"
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".FullName"
-              }
-            }
-          ],
-          "linkId": "16.2",
-          "text": "Name (Printed):",
-          "type": "string",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".Today"
-              }
-            }
-          ],
-          "linkId": "16.3",
-          "text": "Date (MM/DD/YYYY):",
-          "type": "date",
-          "required": true
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".NPI"
-              }
-            }
-          ],
-          "linkId": "16.4",
-          "text": "NPI:",
-          "type": "string",
-          "required": true
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/provider-signature"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Provider Signature"
     }
   ]
 }

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -92,11 +92,6 @@
           "type": "open-choice",
           "answerOption": [],
           "repeats": "true"
-        },
-        {
-          "linkId": "4.3",
-          "text": "Describe",
-          "type": "text"
         }
       ]
     },

--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -111,6 +111,12 @@
           "type": "integer",
           "extension": [
             {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+              "valueCoding": {
+                "display": "per hour"
+              }
+            },
+            {
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
@@ -124,6 +130,12 @@
           "text": "Respiratory Disturbance index (RDI) units of events per hour",
           "type": "integer",
           "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+              "valueCoding": {
+                "display": "per hour"
+              }
+            },
             {
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {

--- a/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
+++ b/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
@@ -6,9 +6,22 @@ codesystem "HL7-V2-0136": 'http://terminology.hl7.org/CodeSystem/v2-0136'
 
 code "Yes": 'Y' from "HL7-V2-0136" display 'Yes'
 
+parameter device_request DeviceRequest
+parameter service_request ServiceRequest
+parameter medication_request MedicationRequest
+
 context Patient
 
-define Today: Today()
+define "Today": Today()
+
+define "RequestEncounterReference": Coalesce(device_request.encounter.reference.value, service_request.encounter.reference.value, medication_request.encounter.reference.value)
+define "RequestEncounter": 
+  [Encounter] E
+  where 'Encounter/'+ E.id = "RequestEncounterReference"
+
+define "RequestEncounterDate":
+  if exists("RequestEncounter") then "RequestEncounter".period.start.value
+  else "Today"
 
 /* This is a work around to prepopulate with Yes answer for Yes/No question.
    The blocking issue is that when LHC form control merge Questionnaire (the compiled static form)

--- a/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
+++ b/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
@@ -1,0 +1,163 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "encounter-with-reevaluation",
+    "name": "Encounter With Reevaluation Module",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/StructureDefinition/cqf-questionnaire",
+            "http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-r4"
+        ]
+    },
+    "extension": [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
+            "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicClinicalInfo-prepopulation"
+        }
+    ],
+    "status": "draft",
+    "item": [
+        {
+            "linkId": "ENC",
+            "type": "group",
+            "text": "Encounter",
+            "item": [
+                {
+                    "linkId": "ENC.1",
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                            "valueExpression": {
+                                "language": "text/cql",
+                                "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+                            }
+                        }
+                    ],
+                    "text": "Date of encounter (MM/DD/YYYY)",
+                    "type": "date",
+                    "required": true
+                },
+                {
+                    "linkId": "ENC.2",
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                            "valueExpression": {
+                                "language": "text/cql",
+                                "expression": "\"BasicClinicalInfoPrepopulation\".AnswerYes"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "code": "radio-button",
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "text": "Is this encounter for the evaluation of the patient’s need for ordered device, service, or medication?",
+                    "required": true,
+                    "type": "choice",
+                    "answerValueSet": "http://terminology.hl7.org/ValueSet/v2-0136"
+                },
+                {
+                    "linkId": "ENC.3",
+                    "text": "Evaluation details",
+                    "type": "group",
+                    "enableWhen": [
+                        {
+                            "question": "ENC.2",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "Y",
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "linkId": "ENC.3.1",
+                            "text": "Type",
+                            "type": "choice",
+                            "required": true,
+                            "enableWhen": [
+                                {
+                                    "question": "ENC.2",
+                                    "operator": "=",
+                                    "answerCoding": {
+                                        "code": "Y",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                                    }
+                                }
+                            ],
+                            "answerOption": [
+                                {
+                                    "valueCoding": {
+                                        "code": "Initial Evaluation"
+                                    }
+                                },
+                                {
+                                    "valueCoding": {
+                                        "code": "Re-evaluation"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "linkId": "ENC.3.2",
+                            "text": "Is there evidence of continued use of the PAP/CPAP device and supplies?",
+                            "type": "choice",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "coding": [
+                                            {
+                                                "code": "radio-button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "enableWhen": [
+                                {
+                                    "question": "ENC.3.1",
+                                    "operator": "=",
+                                    "answerCoding": {
+                                        "code": "Re-evaluation"
+                                    }
+                                }
+                            ],
+                            "answerValueSet": "http://terminology.hl7.org/ValueSet/v2-0136"
+                        },
+                        {
+                            "linkId": "ENC.3.3",
+                            "text": "Describe",
+                            "type": "text"
+                        }
+                    ]
+                },
+                {
+                    "linkId": "ENC.4",
+                    "text": "If No, purpose of the encounter",
+                    "type": "text",
+                    "required": true,
+                    "enableWhen": [
+                        {
+                            "question": "ENC.2",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "N",
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
+++ b/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
@@ -32,7 +32,7 @@
                             }
                         }
                     ],
-                    "text": "Date of encounter (MM/DD/YYYY)",
+                    "text": "Date of encounter:",
                     "type": "date",
                     "required": true
                 },
@@ -42,8 +42,8 @@
                         {
                             "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
                             "valueExpression": {
-                                "language": "text/cql",
-                                "expression": "\"BasicClinicalInfoPrepopulation\".AnswerYes"
+                            "language": "text/cql",
+                            "expression": "\"BasicClinicalInfoPrepopulation\".AnswerYes"
                             }
                         },
                         {
@@ -51,118 +51,122 @@
                             "valueCodeableConcept": {
                                 "coding": [
                                     {
-                                        "code": "radio-button",
-                                        "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                    "code": "radio-button",
+                                    "system": "http://hl7.org/fhir/questionnaire-item-control"
                                     }
                                 ]
                             }
                         }
                     ],
-                    "text": "Is this encounter for the evaluation of the patient’s need for ordered device, service, or medication?",
-                    "required": true,
+                    "text": "Is this encounter for the evaluation of the patient’s need for the ordered device, service, or medication?",
                     "type": "choice",
-                    "answerValueSet": "http://terminology.hl7.org/ValueSet/v2-0136"
-                },
-                {
-                    "linkId": "ENC.3",
-                    "text": "Evaluation details",
-                    "type": "group",
-                    "enableWhen": [
-                        {
-                            "question": "ENC.2",
-                            "operator": "=",
-                            "answerCoding": {
-                                "code": "Y",
-                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
-                            }
-                        }
-                    ],
+                    "answerValueSet": "http://terminology.hl7.org/ValueSet/v2-0136",
+                    "required": true,
                     "item": [
                         {
-                            "linkId": "ENC.3.1",
-                            "text": "Type",
-                            "type": "choice",
+                            "linkId": "ENC.2.1",
+                            "text": "If Yes, is this an initial evaluation or a re-evaluation?",
+                            "type": "open-choice",
                             "required": true,
+                            "answerOption": [
+                            {
+                                "valueCoding": {
+                                "code": "initial-evaluation",
+                                "display": "Initial Evaluation"
+                                }
+                            },
+                            {
+                                "valueCoding": {
+                                "code": "re-evaluation",
+                                "display": "Re-evaluation"
+                                }
+                            }
+                            ],
+                            "enableWhen": [
+                            {
+                                "question": "ENC.2",
+                                "operator": "=",
+                                "answerCoding": {
+                                "code": "Y",
+                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
+                                }
+                            }
+                            ],
+                            "item":[
+                                {
+                                    "linkId": "ENC.2.1.1",
+                                    "text": "Is there evidence of continued use of the ordered device & supplies, service, or medication?",
+                                    "type": "choice",
+                                    "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                        "valueCodeableConcept": {
+                                            "coding": [
+                                                {
+                                                "code": "radio-button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                    ],
+                                    "answerOption": [
+                                    {
+                                        "valueCoding": {
+                                        "code": "Y",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                        "display": "Yes"
+                                        }
+                                    },
+                                    {
+                                        "valueCoding": {
+                                        "code": "N",
+                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                        "display": "No"
+                                        }
+                                    }
+                                    ],
+                                    "enableWhen": [
+                                        {
+                                            "question": "ENC.2.1",
+                                            "operator": "=",
+                                            "answerCoding": {
+                                            "code": "re-evaluation"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "linkId": "ENC.2.1.2",
+                                    "text": "Describe:",
+                                    "type": "string",
+                                    "enableWhen": [
+                                        {
+                                            "question": "ENC.2.1",
+                                            "operator": "=",
+                                            "answerCoding": {
+                                            "code": "re-evaluation"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "linkId": "ENC.2.2",
+                            "text": "If No, purpose of the encounter",
+                            "type": "text",
+                            "require": true,
                             "enableWhen": [
                                 {
                                     "question": "ENC.2",
                                     "operator": "=",
                                     "answerCoding": {
-                                        "code": "Y",
-                                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
-                                    }
-                                }
-                            ],
-                            "answerOption": [
-                                {
-                                    "valueCoding": {
-                                        "code": "Initial Evaluation"
-                                    }
-                                },
-                                {
-                                    "valueCoding": {
-                                        "code": "Re-evaluation"
+                                    "code": "N",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
                                     }
                                 }
                             ]
-                        },
-                        {
-                            "linkId": "ENC.3.2",
-                            "text": "Is there evidence of continued use of the ordered devices, supplies and services?",
-                            "type": "choice",
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "code": "radio-button",
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
-                                            }
-                                        ]
-                                    }
-                                }
-                            ],
-                            "enableWhen": [
-                                {
-                                    "question": "ENC.3.1",
-                                    "operator": "=",
-                                    "answerCoding": {
-                                        "code": "Re-evaluation"
-                                    }
-                                }
-                            ],
-                            "answerValueSet": "http://terminology.hl7.org/ValueSet/v2-0136"
-                        },
-                        {
-                            "linkId": "ENC.3.3",
-                            "text": "Describe",
-                            "type": "text",
-                            "enableWhen": [
-                                {
-                                    "question": "ENC.3.1",
-                                    "operator": "=",
-                                    "answerCoding": {
-                                        "code": "Re-evaluation"
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "linkId": "ENC.4",
-                    "text": "If No, purpose of the encounter",
-                    "type": "text",
-                    "required": true,
-                    "enableWhen": [
-                        {
-                            "question": "ENC.2",
-                            "operator": "=",
-                            "answerCoding": {
-                                "code": "N",
-                                "system": "http://terminology.hl7.org/CodeSystem/v2-0136"
-                            }
                         }
                     ]
                 }

--- a/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
+++ b/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
@@ -108,7 +108,7 @@
                         },
                         {
                             "linkId": "ENC.3.2",
-                            "text": "Is there evidence of continued use of the PAP/CPAP device and supplies?",
+                            "text": "Is there evidence of continued use of the ordered devices, supplies and services?",
                             "type": "choice",
                             "extension": [
                                 {

--- a/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
+++ b/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
@@ -137,7 +137,16 @@
                         {
                             "linkId": "ENC.3.3",
                             "text": "Describe",
-                            "type": "text"
+                            "type": "text",
+                            "enableWhen": [
+                                {
+                                    "question": "ENC.3.1",
+                                    "operator": "=",
+                                    "answerCoding": {
+                                        "code": "Re-evaluation"
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },

--- a/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
+++ b/Shared/R4/resources/Questionnaire-R4-EncounterWithReevaluation.json
@@ -28,7 +28,7 @@
                             "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
                             "valueExpression": {
                                 "language": "text/cql",
-                                "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+                                "expression": "\"BasicClinicalInfoPrepopulation\".RequestEncounterDate"
                             }
                         }
                     ],


### PR DESCRIPTION
This PR refactors the rulesets for CPAP based on latest changes
1. Using the newly defined valueset for both CQL and questionnaire
2. Using sub-questionnaire if applicable
3. Adding subquestionnaire EncounterWithReevaluation
4. For order form, display the encounter date if the request has a reference to an encounter; otherwise, prepopulate the date as Today's date. Put the statement in BasicaClinicalPrepopulation library so people can use it across different topics. 

The test data are updated in this PR (branch name papvs): test-ehr PR: https://github.com/HL7-DaVinci/test-ehr/pull/36

To Test:
Patient: Roosevelt Theodore
E0470 device request doesn't have a reference for encounter
E0601 has a referenced encounter