### PR TITLE
DMEERX-791 Modify BasicPractitioner sub-questionnaire to display Encounter Provider

### DIFF
--- a/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
+++ b/PositiveAirwayPressureDevices/R4/resources/Questionnaire-R4-PositiveAirwayPressureDevicesFaceToFace.json
@@ -108,7 +108,7 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
               "valueCoding": {
-                "display": "per hour"
+                "display": "/h"
               }
             },
             {
@@ -128,7 +128,7 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
               "valueCoding": {
-                "display": "per hour"
+                "display": "/h"
               }
             },
             {

--- a/RespiratoryAssistDevices/R4/resources/Questionnaire-R4-RespiratoryAssistDevices.json
+++ b/RespiratoryAssistDevices/R4/resources/Questionnaire-R4-RespiratoryAssistDevices.json
@@ -46,33 +46,11 @@
     },
     {
       "linkId": "3",
-      "text": "Encounter",
-      "type": "group",
-      "item": [
-        {
-          "linkId": "3.1",
-          "text": "Date of F2F encounter",
-          "type": "date",
-          "required": true,
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"RespiratoryAssistDevicesPrepopulation\".EncounterDate"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "linkId": "4",
       "text": "Respiratory Assist Device Diagnoses",
       "type": "group",
       "item": [
         {
-          "linkId": "4.1",
+          "linkId": "3.1",
           "type": "open-choice",
           "text": "Patient diagnoses for order",
           "required": false,
@@ -88,7 +66,7 @@
           ]
         },
         {
-          "linkId": "4.2",
+          "linkId": "3.2",
           "text": "Other Diagnoses:",
           "type": "open-choice",
           "extension": [
@@ -106,38 +84,38 @@
       ]
     },
     {
-      "linkId": "5",
+      "linkId": "4",
       "text": "RAD for OSA Order Information",
       "type": "group",
       "item": [
         {
-          "linkId": "5.1",
+          "linkId": "4.1",
           "text": "Start date if different from order date",
           "type": "date",
           "required": false
         },
         {
-          "linkId": "5.2",
+          "linkId": "4.2",
           "type": "open-choice",
           "text": "Type of Device Order",
           "required": true,
           "answerValueSet": "http://hl7.org/fhir/ValueSet/request-intent"
         },
         {
-          "linkId": "5.3",
+          "linkId": "4.3",
           "type": "open-choice",
           "text": "Type of Supply Order",
           "required": true,
           "answerValueSet": "http://hl7.org/fhir/ValueSet/request-intent"
         },
         {
-          "linkId": "5.4",
+          "linkId": "4.4",
           "text": "If Other, describe",
           "type": "string",
           "required": true,
           "enableWhen": [
             {
-              "question": "5.3",
+              "question": "4.3",
               "operator": "=",
               "answerCoding": {
                 "code": "Other"
@@ -146,18 +124,18 @@
           ]
         },
         {
-          "linkId": "5.5",
+          "linkId": "4.5",
           "text": "Device Order (description of device)",
           "type": "string",
           "required": true
         },
         {
-          "linkId": "5.6",
+          "linkId": "4.6",
           "text": "Specific Device",
           "type": "group",
           "item": [
             {
-              "linkId": "5.6.1",
+              "linkId": "4.6.1",
               "text": "Specify",
               "type": "choice",
               "extension": [
@@ -185,17 +163,17 @@
               ]
             },
             {
-              "linkId": "5.6.2",
+              "linkId": "4.6.2",
               "text": "Note:  RAD (E0470 and E0471) require Written Order Prior to Delivery and F2F Evaluation",
               "type": "display"
             },
             {
-              "linkId": "5.6.3",
+              "linkId": "4.6.3",
               "text": "Note:  E0471 is not covered for OSA",
               "type": "display",
               "enableWhen": [
                 {
-                  "question": "5.6.1",
+                  "question": "4.6.1",
                   "operator": "=",
                   "answerCoding": {
                     "code": "E0471"
@@ -206,7 +184,7 @@
           ]
         },
         {
-          "linkId": "5.7",
+          "linkId": "4.7",
           "text": "Supply",
           "type": "group",
           "repeats": true,
@@ -225,33 +203,33 @@
           ],
           "item": [
             {
-              "linkId": "5.7.1",
+              "linkId": "4.7.1",
               "type": "choice",
               "text": "Order",
               "answerValueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.129"
             },
             {
-              "linkId": "5.7.2",
+              "linkId": "4.7.2",
               "text": "Item Description",
               "type": "string"
             },
             {
-              "linkId": "5.7.3",
+              "linkId": "4.7.3",
               "text": "Frequency",
               "type": "string"
             },
             {
-              "linkId": "5.7.4",
+              "linkId": "4.7.4",
               "text": "Duration",
               "type": "string"
             },
             {
-              "linkId": "5.7.5",
+              "linkId": "4.7.5",
               "text": "Quantity",
               "type": "string"
             },
             {
-              "linkId": "5.7.6",
+              "linkId": "4.7.6",
               "text": "Refills",
               "type": "string"
             }
@@ -260,7 +238,7 @@
       ]
     },
     {
-      "linkId": "6",
+      "linkId": "5",
       "extension": [
         {
           "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",

--- a/RespiratoryAssistDevices/R4/resources/Questionnaire-R4-RespiratoryAssistDevicesLab.json
+++ b/RespiratoryAssistDevices/R4/resources/Questionnaire-R4-RespiratoryAssistDevicesLab.json
@@ -38,58 +38,14 @@
     },
     {
       "linkId": "2",
-      "type": "group",
-      "text": "Provider (physician/NPP) who is performing the face-to-face evaluation:",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-          "valueCodeableConcept": {
-            "coding": [
-              {
-                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                "code": "gtable"
-              }
-            ]
-          }
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/practitioner-info"
         }
       ],
-      "item": [
-        {
-          "linkId": "2.1",
-          "text": "Last Name",
-          "type": "text"
-        },
-        {
-          "linkId": "2.2",
-          "text": "First Name",
-          "type": "text"
-        },
-        {
-          "linkId": "2.3",
-          "text": "MI",
-          "type": "text"
-        },
-        {
-          "linkId": "2.4",
-          "text": "NPI",
-          "type": "text"
-        },
-        {
-          "linkId": "2.5",
-          "text": "Date of F2F encounter",
-          "type": "date",
-          "required": true,
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"RespiratoryAssistDevicesPrepopulation\".EncounterDate"
-              }
-            }
-          ]
-        }
-      ]
+      "type": "display",
+      "text": "This is a placeholder for Physician/NPP Demographics"
     },
     {
       "linkId": "3",
@@ -751,39 +707,14 @@
     },
     {
       "linkId": "5",
-      "text": "Signature",
-      "type": "group",
-      "item": [
+      "extension": [
         {
-          "linkId": "5.1",
-          "text": "Signature",
-          "type": "text"
-        },
-        {
-          "linkId": "5.2",
-          "text": "Name (Printed)",
-          "type": "text"
-        },
-        {
-          "linkId": "5.3",
-          "text": "Date",
-          "type": "date",
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"BasicClinicalInfoPrepopulation\".Today"
-              }
-            }
-          ]
-        },
-        {
-          "linkId": "5.4",
-          "text": "NPI",
-          "type": "text"
+          "url": "http://hl7.org/fhir/StructureDefinition/sub-questionnaire",
+          "valueCanonical": "questionnaire/provider-signature"
         }
-      ]
+      ],
+      "type": "display",
+      "text": "This is a placeholder for Provider Signature"
     }
   ]
 }

--- a/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
+++ b/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
@@ -14,6 +14,11 @@ context Patient
 
 define "Today": Today()
 
+define "OrderingProviderReference": Coalesce(device_request.performer.reference.value, service_request.performer.reference.value, medication_request.performer.reference.value)
+define "OrderingProvider": singleton from (
+  [Practitioner] practitioner
+    where ('Practitioner/' + practitioner.id) = "OrderingProviderReference")
+
 define "RequestEncounterReference": Coalesce(device_request.encounter.reference.value, service_request.encounter.reference.value, medication_request.encounter.reference.value)
 define "RequestEncounter": 
   [Encounter] E
@@ -23,6 +28,56 @@ define "RequestEncounterDate":
   if exists("RequestEncounter") then "RequestEncounter".period.start.value
   else "Today"
 
+define "RequestEncounterParticipants": "RequestEncounter".participant
+define "RequestEncounterFirstParticipantReference": 
+  if exists("RequestEncounterParticipants")
+    then "RequestEncounterParticipants"[0].individual.reference.value
+  else null  
+
+define "IsEncounterProviderSameAsOrderingProvider": "OrderingProviderReference" = "RequestEncounterFirstParticipantReference"
+
+define "OrderingProviderName": singleton from (
+  ("OrderingProvider".name name where name.use.value = 'official') 
+  union 
+  "OrderingProvider".name)
+
+// Get Practitioner's Name elements
+define "OrderingProviderLastName": "OrderingProviderName".family.value
+define "OrderingProviderMiddleInitial": GetMiddleInitials("OrderingProviderName")
+define "OrderingProviderFirstName": "OrderingProviderName".given[0].value
+define "OrderingProviderFullName":
+  "OrderingProviderFirstName" + ' ' + "OrderingProviderMiddleInitial" + ' ' + "OrderingProviderLastName"
+
+// Get Practitioner's NPI
+define "OrderingProviderNPI": (singleton from (
+  "OrderingProvider".identifier identifier
+    where identifier.system.value = 'http://hl7.org/fhir/sid/us-npi')).value.value
+
+// Encounter provider's information
+define "EncounterProviderLastName": 
+  if "IsEncounterProviderSameAsOrderingProvider" then "OrderingProviderLastName"
+  else null
+
+define "EncounterProviderMiddleInitial": 
+  if "IsEncounterProviderSameAsOrderingProvider" then "OrderingProviderMiddleInitial"
+  else null
+
+define "EncounterProviderFirstName": 
+  if "IsEncounterProviderSameAsOrderingProvider" then "OrderingProviderFirstName"
+  else null
+
+define "EncounterProviderFullName": 
+  if "IsEncounterProviderSameAsOrderingProvider" then "OrderingProviderFullName"
+  else null
+
+define "EncounterProviderNPI":
+  if "IsEncounterProviderSameAsOrderingProvider" then "OrderingProviderNPI"
+  else null
+
+define function GetMiddleInitials(name FHIR.HumanName):
+  Substring(Combine((name.given given return Substring(given.value,0,1)),', '),3)
+
+ 
 /* This is a work around to prepopulate with Yes answer for Yes/No question.
    The blocking issue is that when LHC form control merge Questionnaire (the compiled static form)
    and QuestionnaireResponse (the CQL expression results) to create a form representation, 

--- a/Shared/R4/resources/Questionnaire-R4-PractitionerInfo.json
+++ b/Shared/R4/resources/Questionnaire-R4-PractitionerInfo.json
@@ -11,7 +11,7 @@
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
-      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicPractitionerInfo-prepopulation"
+      "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/BasicClinicalInfo-prepopulation"
     }
   ],
   "status": "draft",
@@ -41,7 +41,7 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".LastName"
+                "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderLastName"
               }
             }
           ],
@@ -55,7 +55,7 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".FirstName"
+                "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderFirstName"
               }
             }
           ],
@@ -69,7 +69,7 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".MiddleInitial"
+                "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderMiddleInitial"
               }
             }
           ],
@@ -83,12 +83,27 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"BasicPractitionerInfoPrepopulation\".NPI"
+                "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderNPI"
               }
             }
           ],
           "text": "NPI",
           "type": "string"
+        },
+        {
+          "linkId": "PND.5",
+          "text": "Date of F2F encounter",
+          "type": "date",
+          "required": true,
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"BasicClinicalInfoPrepopulation\".RequestEncounterDate"
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Most of the order, F2F, lab and progress note forms are asking to display the detailed information of the provider who performed the Face-to-Face encounter. The PractitionerInfo sub-questionnaire is used to capture the section. 

Changes in this PR:
1. If the DME request has a reference of "encounter" and the encounter's provider is the same as the request's provider, we would use the ordering provider's information to populate the sub-questionnaire
2. Otherwise, we can only pre-populate the date of the encounter or as Today is there is no encounter reference in the request

To test the scenario of 1.
Switch to test-ehr branch: radlab
Use the patient: pat015-rad-encounter"
Device Request: E0470 for Respiratory Assistant Device

For other requests, we don't have encounter reference. 
