### PR TITLE
DMEERX-818 Do not default dates to Today for encounter

### DIFF
--- a/CRD-DTR/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
+++ b/CRD-DTR/Shared/R4/files/BasicClinicalInfoPrepopulation-0.1.0.cql
@@ -27,7 +27,7 @@ define "RequestEncounter":
 
 define "RequestEncounterDate":
   if exists("RequestEncounter") then "RequestEncounter".period.start.value
-  else "Today"
+  else null
 
 define "RequestEncounterParticipants": "RequestEncounter".participant
 define "RequestEncounterFirstParticipantReference": 

--- a/CRD-DTR/Shared/R4/resources/Questionnaire-R4-Encounter.json
+++ b/CRD-DTR/Shared/R4/resources/Questionnaire-R4-Encounter.json
@@ -28,7 +28,7 @@
               "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
               "valueExpression": {
                 "language": "text/cql",
-                "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+                "expression": "\"BasicClinicalInfoPrepopulation\".RequestEncounterDate"
               }
             }
           ],

--- a/CRD-DTR/Shared/R4/resources/Questionnaire-R4-EncounterItems.json
+++ b/CRD-DTR/Shared/R4/resources/Questionnaire-R4-EncounterItems.json
@@ -23,7 +23,7 @@
           "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
           "valueExpression": {
             "language": "text/cql",
-            "expression": "\"BasicClinicalInfoPrepopulation\".Today"
+            "expression": "\"BasicClinicalInfoPrepopulation\".RequestEncounterDate"
           }
         }
       ],


### PR DESCRIPTION
This PR address the issue reported by https://jira.mitre.org/browse/DMEERX-818

There are three subquestionnaires modified to fix the issue. 
Here are the forms used by the subquestionnaires by the three sub-questionnaires:

**Encounter**
HBGMFaceToFace
HOTFaceToFace
ImmunoSuppressiveDrugsProgressNote
NEATProgressNote
UrologicalSuppliesProgressNote

**encounter-with-reevaluation**
CPAPProgressNote
RADF2F
VentilatorProgressNote 

**encounter-items**
HospitalBedF2F

To test:
1. Open the above forms
2. If the DeviceRequest, ServiceRequest or MedicationRequest has a reference to an encounter, the encounter date will be re-populated with the encounter date
3. if there is no reference to an encounter, the date will not be pre-populated.
4. The following DeviceRequest and ServiceRequest have reference to an encounter
Patient: pat014
DeviceRequest: CPAP (E0601)
ServiceRequest: HHS (G0108)
