### PR TITLE
Support MedicationDispense for ImmunosuppressiveDrugs

### DIFF
--- a/CRD-DTR/HomeHealthServices/R4/resources/Questionnaire-R4-HomeHealthServicesFaceToFace.json
+++ b/CRD-DTR/HomeHealthServices/R4/resources/Questionnaire-R4-HomeHealthServicesFaceToFace.json
@@ -814,10 +814,7 @@
               "linkId": "11.2",
               "text": "Frequency",
               "type": "choice",
-              "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation",
-              "extension": [
-                {}
-              ]
+              "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation"
             },
             {
               "linkId": "11.3",
@@ -918,10 +915,7 @@
               "linkId": "13.1.2",
               "text": "Frequency",
               "type": "choice",
-              "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation",
-              "extension": [
-                {}
-              ]
+              "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation"
             },
             {
               "linkId": "13.1.3",
@@ -990,10 +984,7 @@
           "linkId": "14.2",
           "text": "Frequency",
           "type": "choice",
-          "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation",
-          "extension": [
-            {}
-          ]
+          "answerValueSet": "http://hl7.org/fhir/ValueSet/timing-abbreviation"
         },
         {
           "linkId": "14.3",

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
@@ -15,6 +15,7 @@ valueset "ImmunosuppressiveSupportiveMedicationValueSet": 'http://cts.nlm.nih.go
 
 
 parameter medication_request MedicationRequest
+parameter medication_dispense MedicationDispense
 
 context Patient
 
@@ -30,8 +31,10 @@ define "TransplantDate":
   else First("QualifyingTransplantProcedures").performed.value union First("QualifyingTransplantProcedures").performed.start.value
 
 // Get all medication related information
+define "MedicationCodingFromParameter": Coalesce(medication_request.medication.coding, medication_dispense.medication.coding)
+
 define MedicationCoding: singleton from (
-  (medication_request.medication.coding) CODING
+    "MedicationCodingFromParameter" CODING
     where CODING in "ImmunosuppressiveMedicationValueSet" 
     or CODING in "ImmunosuppressiveSupportiveMedicationValueSet")
 
@@ -39,11 +42,11 @@ define "MedicationName": MedicationCoding.display.value
 
 define "MedicationCode" : MedicationCoding.code.value
 
-define "MedicationDosage": medication_request.dosageInstruction[0]
+define "MedicationDosage": Coalesce(medication_request.dosageInstruction[0], medication_dispense.dosageInstruction[0])
 
 define "MedicationDoseAndRate": MedicationDosage.doseAndRate[0]
 
-define "MedicationDoseWithUnit": ToString(MedicationDoseAndRate.dose.value.value) + '' + MedicationDoseAndRate.dose.unit.value
+define "MedicationDoseWithUnit": ToString(MedicationDoseAndRate.dose.value.value) + ' ' + MedicationDoseAndRate.dose.unit.value
 
 define "MedicationRoute": MedicationDosage.route.coding[0].display.value
 
@@ -51,3 +54,11 @@ define "MedicationFrequency" : ToString(MedicationDosage.timing.repeat.frequency
 
 define CurrentDiagnoses:
   DTR.CodesFromConditions(CDS.Confirmed(CDS.ActiveOrRecurring([Condition]))) except QualifyingTransplant
+
+define "MedicationQuantity": Coalesce(medication_dispense.quantity.value, medication_request.dispenseRequest.quantity.value.value)
+
+define "MedicationRefill": 
+  if medication_request.dispenseRequest is not null
+    then medication_request.dispenseRequest.numberOfRepeatsAllowed.value
+  else
+    null  

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
@@ -62,3 +62,5 @@ define "MedicationRefill":
     then medication_request.dispenseRequest.numberOfRepeatsAllowed.value
   else
     null  
+
+define "IsMedicationRequest": medication_request.id is not null

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsPrepopulation-0.1.0.cql
@@ -22,7 +22,7 @@ define "QualifyingTransplant": [Condition: "OrganTransplantHistoryValueSet"]
 
 define "QualifyingTransplantProcedures": [Procedure: "OrganTransplantProcedureValueSet"]
 
-define "QualifyingTransplantCodings": DTR.CodesFromConditions("QualifyingTransplant") union DTR.ProcedureCoding("QualifyingTransplantProcedures")
+define "QualifyingTransplantCodings": DTR.CodesFromConditions("QualifyingTransplant") union DTR.CodesFromProcedures("QualifyingTransplantProcedures")
 
 // get the first transplant date
 define "TransplantDate": 

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
@@ -4,6 +4,7 @@ include FHIRHelpers version '4.0.0' called FHIRHelpers
 
 parameter Patient Patient
 parameter medication_request MedicationRequest
+parameter medication_dispense MedicationDispense
 
 define RULE_APPLIES:
     true
@@ -24,10 +25,16 @@ define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforHospitalBedsandAccessories-ICN909476.pdf'
 
 define RESULT_QuestionnaireOrderUri:
-    'Questionnaire/ImmunosuppressiveDrugs'
+    'Questionnaire/ImmunosuppressiveDrugs'  
+
+define RESULT_QuestionnaireDispenseUri:
+    'Questionnaire/ImmunosuppressiveDrugs'  
 
 define RESULT_QuestionnaireProgressNoteUri:
     'Questionnaire/ImmunosuppressiveDrugsProgressNote'
 
 define RESULT_requestId:
   medication_request
+
+define RESULT_dispense:
+  medication_dispense

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/resources/Questionnaire-R4-ImmunosuppressiveDrugs.json
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/resources/Questionnaire-R4-ImmunosuppressiveDrugs.json
@@ -153,15 +153,80 @@
         },
         {
           "linkId": "5.7",
-          "type": "integer",
-          "text": "Refill",
-          "extension": [
+          "text": "More details",
+          "type": "group",
+          "item": [
             {
-              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
-              "valueExpression": {
-                "language": "text/cql",
-                "expression": "\"ImmunosuppressiveDrugsPrepopulation\".MedicationRefill"
-              }
+              "linkId": "5.7.1",
+              "type": "boolean",
+              "readOnly": true,
+              "text": "Is for Medication Request?",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"ImmunosuppressiveDrugsPrepopulation\".IsMedicationRequest"
+                  }
+                }
+              ]
+            },
+            {
+              "linkId": "5.7.2",
+              "type": "integer",
+              "text": "Refill",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"ImmunosuppressiveDrugsPrepopulation\".MedicationRefill"
+                  }
+                }
+              ],
+              "enableWhen": [
+                {
+                  "question": "5.7.1",
+                  "operator": "=",
+                  "answerBoolean": true
+                }
+              ]
+            },
+            {
+              "linkId": "5.7.3",
+              "type": "date",
+              "text": "Date the above drugs and supplies were dispensed to the patient",
+              "enableWhen": [
+                {
+                  "question": "5.7.1",
+                  "operator": "=",
+                  "answerBoolean": false
+                }
+              ]
+            },
+            {
+              "linkId": "5.7.4",
+              "type": "text",
+              "text": "NSC number",
+              "enableWhen": [
+                {
+                  "question": "5.7.1",
+                  "operator": "=",
+                  "answerBoolean": false
+                }
+              ]
+            },
+            {
+              "linkId": "5.7.5",
+              "type": "text",
+              "text": "State dispensing license number",
+              "enableWhen": [
+                {
+                  "question": "5.7.1",
+                  "operator": "=",
+                  "answerBoolean": false
+                }
+              ]
             }
           ]
         }

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/resources/Questionnaire-R4-ImmunosuppressiveDrugs.json
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/resources/Questionnaire-R4-ImmunosuppressiveDrugs.json
@@ -64,7 +64,7 @@
     },
     {
       "linkId": "5",
-      "text": "Order",
+      "text": "Immunosuppressive drug(s) ordered and dispensed",
       "type": "group",
       "item": [
         {
@@ -133,6 +133,34 @@
               "valueExpression": {
                 "language": "text/cql",
                 "expression": "\"ImmunosuppressiveDrugsPrepopulation\".MedicationFrequency"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "5.6",
+          "type": "integer",
+          "text": "Quantity",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"ImmunosuppressiveDrugsPrepopulation\".MedicationQuantity"
+              }
+            }
+          ]
+        },
+        {
+          "linkId": "5.7",
+          "type": "integer",
+          "text": "Refill",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"ImmunosuppressiveDrugsPrepopulation\".MedicationRefill"
               }
             }
           ]

--- a/CRD-DTR/Shared/R4/files/DTRHelpers-0.1.0.cql
+++ b/CRD-DTR/Shared/R4/files/DTRHelpers-0.1.0.cql
@@ -92,3 +92,18 @@ define function ProcedureCoding(ProcedureList List<FHIR.Procedure>):
         return DiagnosesCodings
     )
   )
+
+// Returns formatted codings from a list of Procedures
+// Use Case: Query relevant procedures for a MedicationRequest
+  define function CodesFromProcedures(ProcedureList List<FHIR.Procedure>):
+    distinct(flatten(
+      ProcedureList P
+        let DiagnosesCodings:
+            (P.code.coding) CODING where CODING.system.value in {
+              'http://hl7.org/fhir/sid/icd-10',
+              'http://hl7.org/fhir/sid/icd-10-cm',
+              'http://snomed.info/sct'
+            }
+            return FHIRHelpers.ToCode(CODING)
+        return DiagnosesCodings
+  ))


### PR DESCRIPTION
This PR supports MedicationDispense for immunosuppressiveDrugs.

To test:
Need to switch to mdispense for every repo: CRD, DTR, test-ehr and crd-request-generator

From request generator, select patient pat014
Pick medication request 105611, go through the whole DRLS flow to see the order form as before
Pick medication dispense 105611, go through the whole DRLS flow to see the dispense form