### PR TITLE
Remove a trailing comma on a questionnaire. 

### DIFF
--- a/CRD-DTR/Shared/R4/resources/Questionnaire-R4-PhysicalExamVitalSigns.json
+++ b/CRD-DTR/Shared/R4/resources/Questionnaire-R4-PhysicalExamVitalSigns.json
@@ -38,6 +38,6 @@
           "text": "This is a placeholder for Physican Examination"
         }
       ]
-    },
+    }
   ]
 }


### PR DESCRIPTION
It caused a problem with the newer versions of the FHIR parsers.