### PR TITLE
Example CRD rule for handling order-select hook for drug-drug interactions.

### DIFF
--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
@@ -6,6 +6,7 @@ include FHIRHelpers version '4.0.0' called FHIRHelpers
 parameter Patient Patient
 parameter medication_request MedicationRequest
 parameter medication_dispense MedicationDispense
+parameter medication_statement MedicationStatement
 
 define RULE_APPLIES:
     true
@@ -41,8 +42,25 @@ define RESULT_dispense:
   medication_dispense
 
 define "MedicationCodingFromParameter": Coalesce(medication_request.medication.coding, medication_dispense.medication.coding)
+
+define "MedicationStatementCodingFromParamter": medication_statement.medication.coding
   
 define ALTERNATIVE_THERAPY:
   if MedicationCodingFromParameter.code.value in { '105611', '239983' }
   then Code { code: '197388', display: 'Azathioprine 50 MG Oral', system: 'http://www.nlm.nih.gov/research/umls/rxnorm' }
   else null
+
+define DRUG_INTERACTION:
+  if MedicationCodingFromParameter.code.value in { '105585' } 
+    and MedicationStatementCodingFromParamter.code.value in { '105611', '197388', '239983' }
+    then true
+  else if MedicationCodingFromParameter.code.value in { '105611', '197388', '239983' } 
+    and MedicationStatementCodingFromParamter.code.value in { '105585' }
+    then true
+  else false
+
+define REQUESTED_DRUG_CODE:
+  MedicationCodingFromParameter
+
+define STATEMENT_DRUG_CODE:
+  MedicationStatementCodingFromParamter


### PR DESCRIPTION
Update Immunosuppressive CRD rule to look for drug-drug interactions with the order-select hook.