### PR TITLE
[DMEERX-1043] CRD STU2 - Add ability to annotate order with note based on CRD return

### DIFF
--- a/CRD-DTR/HomeBloodGlucoseMonitor/R4/files/HomeBloodGlucoseMonitorRule-0.1.0.cql
+++ b/CRD-DTR/HomeBloodGlucoseMonitor/R4/files/HomeBloodGlucoseMonitorRule-0.1.0.cql
@@ -17,12 +17,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Authorization required.'
-
-define RESULT_Details:
-  'Authorization is required, follow the link for more information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforGlucoseMonitors-ICN909465.pdf'
 

--- a/CRD-DTR/HomeHealthServices/R4/files/HomeHealthServicesRule-0.1.0.cql
+++ b/CRD-DTR/HomeHealthServices/R4/files/HomeHealthServicesRule-0.1.0.cql
@@ -13,12 +13,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Prior Authorization required.'
-
-define RESULT_Details:
-  'Authorization is required, follow the link for more information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/Medicare-Home-Health-Benefit-Text-Only.pdf'
 

--- a/CRD-DTR/HomeOxygenTherapy/R4/files/HomeOxygenTherapyRule-0.1.0.cql
+++ b/CRD-DTR/HomeOxygenTherapy/R4/files/HomeOxygenTherapyRule-0.1.0.cql
@@ -17,12 +17,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required'
-
-define RESULT_Details: 
-  'Documentation Required, please complete forms via Smart App links below.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/outreach-and-education/medicare-learning-network-mln/mlnproducts/downloads/home-oxygen-therapy-text-only.pdf'
 

--- a/CRD-DTR/HospitalBedsAndAccessories/R4/files/HospitalBedsAndAccessoriesRule-0.1.0.cql
+++ b/CRD-DTR/HospitalBedsAndAccessories/R4/files/HospitalBedsAndAccessoriesRule-0.1.0.cql
@@ -5,20 +5,17 @@ include FHIRHelpers version '4.0.0' called FHIRHelpers
 parameter Patient Patient
 parameter device_request DeviceRequest
 
+define "Age":
+  AgeInYears()
+
 define RULE_APPLIES:
-    true
+  true
 
 define PRIORAUTH_REQUIRED:
   false
 
 define DOCUMENTATION_REQUIRED:
-  true
-
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
+  "Age" <= 70
 
 define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforHospitalBedsandAccessories-ICN909476.pdf'

--- a/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
+++ b/CRD-DTR/ImmunosuppressiveDrugs/R4/files/ImmunosuppressiveDrugsRule-0.1.0.cql
@@ -17,12 +17,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
-
 define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforHospitalBedsandAccessories-ICN909476.pdf'
 

--- a/CRD-DTR/NonEmergencyAmbulanceTransportation/R4/files/NonEmergencyAmbulanceTransportationRule-0.1.0.cql
+++ b/CRD-DTR/NonEmergencyAmbulanceTransportation/R4/files/NonEmergencyAmbulanceTransportationRule-0.1.0.cql
@@ -14,12 +14,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Prior Authorization required.'
-
-define RESULT_Details:
-  'Prior Authorization required, follow the attached link for information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNMattersArticles/Downloads/SE1514.pdf'
 

--- a/CRD-DTR/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesRule-0.1.0.cql
+++ b/CRD-DTR/PositiveAirwayPressureDevices/R4/files/PositiveAirwayPressureDevicesRule-0.1.0.cql
@@ -14,12 +14,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
-
 define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/downloads/PAP_DocCvg_Factsheet_ICN905064.pdf'
 

--- a/CRD-DTR/RespiratoryAssistDevices/R4/files/RespiratoryAssistDevicesRule-0.1.0.cql
+++ b/CRD-DTR/RespiratoryAssistDevices/R4/files/RespiratoryAssistDevicesRule-0.1.0.cql
@@ -14,12 +14,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
-
 define RESULT_InfoLink:
     'https://www.cms.gov/Research-Statistics-Data-and-Systems/Computer-Data-and-Systems/Electronic-Clinical-Templates/Downloads/Respiratory-Assist-Device-Order-Template-Draft-20180412-R10b.pdf'
 

--- a/CRD-DTR/UrologicalSupplies/R4/files/UrologicalSuppliesRule-0.1.0.cql
+++ b/CRD-DTR/UrologicalSupplies/R4/files/UrologicalSuppliesRule-0.1.0.cql
@@ -14,12 +14,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
-
 define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforVentilators-MLN9725344Print-Friendly.pdf'
 

--- a/CRD-DTR/Ventilators/R4/files/VentilatorsRule-0.1.0.cql
+++ b/CRD-DTR/Ventilators/R4/files/VentilatorsRule-0.1.0.cql
@@ -14,12 +14,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Documentation Required.'
-
-define RESULT_Details:
-  'Documentation Required, please complete form via Smart App link.'
-
 define RESULT_InfoLink:
     'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforVentilators-MLN9725344Print-Friendly.pdf'
 

--- a/Examples/Hypoxemia/R4/files/HypoxemiaRule-1.0.0.cql
+++ b/Examples/Hypoxemia/R4/files/HypoxemiaRule-1.0.0.cql
@@ -13,12 +13,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Authorization is required.'
-
-define RESULT_Details:
-  'Authorization is required, follow the link for more information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforGlucoseMonitors-ICN909465.pdf'
 

--- a/Examples/LowerLimbProsthesis/R4/files/LowerLimbProsthesisRule-1.0.0.cql
+++ b/Examples/LowerLimbProsthesis/R4/files/LowerLimbProsthesisRule-1.0.0.cql
@@ -13,12 +13,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Authorization is required.'
-
-define RESULT_Details:
-  'Authorization is required, follow the link for more information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/ProviderComplianceTipsforGlucoseMonitors-ICN909465.pdf'
 

--- a/RulesetDevGuide.md
+++ b/RulesetDevGuide.md
@@ -84,12 +84,6 @@ define PRIORAUTH_REQUIRED:
 define DOCUMENTATION_REQUIRED:
   true
 
-define RESULT_Summary:
-  'Prior Authorization required.'
-
-define RESULT_Details:
-  'Prior Authorization required, follow the attached link for information.'
-
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNMattersArticles/Downloads/SE1514.pdf'
 


### PR DESCRIPTION
Remove the RESULT_Summary and RESULT_Details from the CQL CRD Rule files. 
Change the Hospital Bed DOCUMENTATION_REQUIRED rule to apply to ages less than 71 so we can test the rule with a test patient.

Changes must be tested and coordinated between CRD, CDS-Library and crd-request-generator all with the same branch name of annotation-suggestion.

Sending a Hospital Bed DeviceRequest for William Oster will return Documentation Required with links to launch into DTR.
Sending a Hospital Bed DeviceRequest for Theodore Roosevelt will return No Prior Authorization required with a link to "Save Update To EHR". When clicked it'll save an updated device request with a note about the prior authorization. You can load the DeviceRequest from the test-ehr to view the note.