### PR TITLE
Change to support preemptive prior-auth on specific patients.

### DIFF
--- a/CRD-DTR/HomeHealthServices/R4/files/HomeHealthServicesRule-0.1.0.cql
+++ b/CRD-DTR/HomeHealthServices/R4/files/HomeHealthServicesRule-0.1.0.cql
@@ -5,13 +5,20 @@ include FHIRHelpers version '4.0.0' called FHIRHelpers
 parameter Patient Patient
 parameter service_request ServiceRequest
 
+define "Age":
+  AgeInYears()
+
 define RULE_APPLIES:
   true
+
 define PRIORAUTH_REQUIRED:
   true 
 
 define DOCUMENTATION_REQUIRED:
   true
+
+define APPROVE_PRIORAUTH:
+  "Age" >= 70
 
 define RESULT_InfoLink:
   'https://www.cms.gov/Outreach-and-Education/Medicare-Learning-Network-MLN/MLNProducts/Downloads/Medicare-Home-Health-Benefit-Text-Only.pdf'


### PR DESCRIPTION
Add support for preemptive prior auth.

To test you must include the changes for the crd-request-generator in the preemptive-prior-auth branch as well as the CRD in the preemptive_prior_auth branch. Choose Theodor Roosevelt and G0180 Service Request for Medicare-covered home health services under a home health plan of care.