### PR TITLE
Added CQL Rule for coverage checking to HOT

### DIFF
--- a/CRD-DTR/HomeOxygenTherapy/R4/files/HomeOxygenTherapyRule-0.1.0.cql
+++ b/CRD-DTR/HomeOxygenTherapy/R4/files/HomeOxygenTherapyRule-0.1.0.cql
@@ -4,12 +4,13 @@ include FHIRHelpers version '4.0.0' called FHIRHelpers
 
 parameter Patient Patient
 parameter device_request DeviceRequest
+parameter Coverage Coverage
 
 define "Age":
     AgeInYears()
 
 define RULE_APPLIES:
-    "Age" > 0
+    "Age" > 0 and Coverage.class.value = 'Medicare Part A'
 
 define PRIORAUTH_REQUIRED:
   false 


### PR DESCRIPTION
This PR adds an example CQL Rules that can accept and use coverage to determine eligibility for a CQL rule.

To test: William Oster has Medicare Part A and Teddy Roosevelt has Part B. The example CQL rule adds a condition to HomeOxygenTherapy's`RULE_APPLIES` that the coverage must be Medicare Part A. Thus, for William Oster Home Oxygen Therapy should return the expected cards but for Teddy Roosevelt it should return "No Documentation Rules Found"

Use with branches:
- test-ehr: coverage-rules https://github.com/HL7-DaVinci/test-ehr/pull/65
- CRD: coverage rules https://github.com/HL7-DaVinci/CRD/pull/278